### PR TITLE
fix(config): move workspace dependency removal to workflow before npm…

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -110,6 +110,8 @@ jobs:
       - name: Publish to npm
         working-directory: packages/client
         run: |
+          # Remove workspace dependencies before publish / publish 전에 workspace 의존성 제거
+          bun run ../../scripts/prepare-publish.ts package.json
           npm version ${{ needs.detect-package.outputs.version }} --no-git-tag-version --allow-same-version
           npm publish --provenance --access public
         env:
@@ -149,6 +151,8 @@ jobs:
       - name: Publish to npm
         working-directory: packages/server
         run: |
+          # Remove workspace dependencies before publish / publish 전에 workspace 의존성 제거
+          bun run ../../scripts/prepare-publish.ts package.json
           npm version ${{ needs.detect-package.outputs.version }} --no-git-tag-version --allow-same-version
           npm publish --provenance --access public
         env:

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,7 @@
     "build:watch": "bun run build:esm:watch & bun run build:iife:watch",
     "build:esm:watch": "bun build src/index.ts --target browser --format esm --minify --outfile dist/index.esm.js --watch",
     "build:iife:watch": "bun build src/index.ts --target browser --format iife --minify --outfile dist/index.iife.js --watch",
-    "prepublishOnly": "bun run ../../scripts/prepare-publish.ts package.json && bun run build",
+    "prepublishOnly": "bun run build",
     "clean": "rm -rf dist",
     "test": "bun test"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,7 +15,7 @@
     "dev": "bun run --watch src/index.ts",
     "build": "bun build src/index.ts --outdir dist --target node && bun run build:types",
     "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "prepublishOnly": "bun run ../../scripts/prepare-publish.ts package.json && bun run build",
+    "prepublishOnly": "bun run build",
     "start": "bun run dist/index.js",
     "test": "bun test"
   },


### PR DESCRIPTION
… publish

- Add prepare-publish.ts script execution in workflow before npm publish

- Remove script from prepublishOnly hook (npm validates before hook execution)

- Apply to both client and server packages