### PR TITLE
refactor(config): simplify npm publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -110,10 +110,7 @@ jobs:
       - name: Publish to npm
         working-directory: packages/client
         run: |
-          # Remove workspace dependencies before publish / publish 전에 workspace 의존성 제거
-          bun run ../../scripts/prepare-publish.ts package.json
-          npm version ${{ needs.detect-package.outputs.version }} --no-git-tag-version --allow-same-version
-          npm publish --provenance --access public
+          npm publish --provenance --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -151,9 +148,6 @@ jobs:
       - name: Publish to npm
         working-directory: packages/server
         run: |
-          # Remove workspace dependencies before publish / publish 전에 workspace 의존성 제거
-          bun run ../../scripts/prepare-publish.ts package.json
-          npm version ${{ needs.detect-package.outputs.version }} --no-git-tag-version --allow-same-version
-          npm publish --provenance --access public
+          npm publish --provenance --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,6 @@
     "build:watch": "bun run build:esm:watch & bun run build:iife:watch",
     "build:esm:watch": "bun build src/index.ts --target browser --format esm --minify --outfile dist/index.esm.js --watch",
     "build:iife:watch": "bun build src/index.ts --target browser --format iife --minify --outfile dist/index.iife.js --watch",
-    "prepublishOnly": "bun run build",
     "clean": "rm -rf dist",
     "test": "bun test"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,7 +15,6 @@
     "dev": "bun run --watch src/index.ts",
     "build": "bun build src/index.ts --outdir dist --target node && bun run build:types",
     "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
-    "prepublishOnly": "bun run build",
     "start": "bun run dist/index.js",
     "test": "bun test"
   },


### PR DESCRIPTION
- Remove npm version command (use package.json version directly)

- Remove prepare-publish.ts script from workflow

- Remove prepublishOnly scripts (build already done in workflow)

- Add --tag latest to npm publish for all versions