### PR TITLE
fix(config): add repository field for trusted publishing provenance

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@ohah/chrome-remote-devtools-client",
   "version": "0.1.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ohah/chrome-remote-devtools.git"
+  },
   "files": [
     "dist",
     "README.md"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@ohah/chrome-remote-devtools-server",
   "version": "0.1.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ohah/chrome-remote-devtools.git"
+  },
   "bin": {
     "chrome-remote-devtools-server": "./dist/index.js"
   },


### PR DESCRIPTION
- Add repository field to client and server package.json

- Required for Trusted Publishing provenance verification

- Repository URL must match GitHub Actions provenance