### PR TITLE
fix(react-native-inspector): fix iOS build errors for Runtime.getProperties

### DIFF
--- a/packages/react-native-inspector/cpp/console/ConsoleRuntime.cpp
+++ b/packages/react-native-inspector/cpp/console/ConsoleRuntime.cpp
@@ -60,7 +60,7 @@ facebook::jsi::Value findObjectById(facebook::jsi::Runtime& runtime, const std::
               LOGW("findObjectById: Map.get returned non-object for objectId=%s / Map.get이 objectId=%s에 대해 객체가 아닌 값 반환", objectId.c_str(), objectId.c_str());
             } else {
               LOGI("findObjectById: Found object in Map for objectId=%s / Map에서 objectId=%s인 객체 찾음", objectId.c_str(), objectId.c_str());
-              return objValue;  // Found in Map! / Map에서 찾음!
+              return std::move(objValue);  // Found in Map! / Map에서 찾음!
             }
           } catch (const std::exception& e) {
             LOGW("findObjectById: Exception calling Map.get: %s / Map.get 호출 중 예외: %s", e.what(), e.what());
@@ -74,7 +74,7 @@ facebook::jsi::Value findObjectById(facebook::jsi::Runtime& runtime, const std::
             facebook::jsi::Value objValue = cdpObjectsObj.getProperty(runtime, objectId.c_str());
             if (!objValue.isUndefined() && objValue.isObject() && !objValue.isNull()) {
               LOGI("findObjectById: Found object in __cdpObjects for objectId=%s / __cdpObjects에서 objectId=%s인 객체 찾음", objectId.c_str(), objectId.c_str());
-              return objValue;
+              return std::move(objValue);
             }
           } catch (...) {
             LOGW("findObjectById: Exception getting property from __cdpObjects / __cdpObjects에서 속성 가져오기 중 예외");
@@ -108,7 +108,7 @@ facebook::jsi::Value findObjectById(facebook::jsi::Runtime& runtime, const std::
             if (cdpIdValue.isString()) {
               std::string cdpId = cdpIdValue.asString(runtime).utf8(runtime);
               if (cdpId == objectId) {
-                return propValue;  // Found! / 찾음!
+                return std::move(propValue);  // Found! / 찾음!
               }
             }
 
@@ -149,7 +149,7 @@ facebook::jsi::Value findObjectById(facebook::jsi::Runtime& runtime, const std::
                 if (cdpIdValue.isString()) {
                   std::string cdpId = cdpIdValue.asString(runtime).utf8(runtime);
                   if (cdpId == objectId) {
-                    return propValue;
+                    return std::move(propValue);
                   }
                 }
               }

--- a/packages/react-native-inspector/ios/ChromeRemoteDevToolsInspector/ChromeRemoteDevToolsInspectorWebSocketAdapter.mm
+++ b/packages/react-native-inspector/ios/ChromeRemoteDevToolsInspector/ChromeRemoteDevToolsInspectorWebSocketAdapter.mm
@@ -260,12 +260,15 @@ NSString *NSStringFromUTF8StringView(std::string_view view)
       NSString *objectId = params[@"objectId"] ?: @"";
       RCTLogInfo(@"[ChromeRemoteDevTools] Runtime.getProperties detected! / Runtime.getProperties 감지됨: objectId=%@", objectId);
 
+      // Convert NSNumber to NSString for method parameter / 메서드 파라미터를 위해 NSNumber를 NSString로 변환
+      NSString *requestIdString = [requestId stringValue];
+
       // Get object properties from C++ hook via Module / Module을 통해 C++ 훅에서 객체 속성 가져오기
       // Note: This is async, so we handle response in completion handler / 참고: 이것은 비동기이므로 completion handler에서 응답 처리
       [ChromeRemoteDevToolsInspectorModule getObjectProperties:objectId completion:^(NSString *propertiesJson) {
         if (!propertiesJson || propertiesJson.length == 0) {
           RCTLogInfo(@"[ChromeRemoteDevTools] Object properties not found for objectId / objectId에 대한 객체 속성을 찾을 수 없음: %@", objectId);
-          [self sendEmptyPropertiesResponse:requestId];
+          [self sendEmptyPropertiesResponse:requestIdString];
           return;
         }
 
@@ -276,7 +279,7 @@ NSString *NSStringFromUTF8StringView(std::string_view view)
 
         if (parseError || !propertiesResult) {
           RCTLogError(@"[ChromeRemoteDevTools] Failed to parse properties JSON / 속성 JSON 파싱 실패: %@", parseError);
-          [self sendEmptyPropertiesResponse:requestId];
+          [self sendEmptyPropertiesResponse:requestIdString];
           return;
         }
 


### PR DESCRIPTION
## Summary

Fix iOS build errors for `Runtime.getProperties` implementation.

## Changes

- **WebSocketAdapter.mm**: Convert `NSNumber *requestId` to `NSString *` for method parameter
- **ConsoleRuntime.cpp**: Use `std::move()` for `jsi::Value` return statements to avoid copy constructor errors

## Files Changed

- `packages/react-native-inspector/ios/ChromeRemoteDevToolsInspector/ChromeRemoteDevToolsInspectorWebSocketAdapter.mm`
- `packages/react-native-inspector/cpp/console/ConsoleRuntime.cpp`

## Build Status

- ✅ iOS: Compilation errors fixed
- ✅ Android: No changes needed