### PR TITLE
feat(ci): add Maestro iOS test workflow

### DIFF
--- a/.github/workflows/test-maestro-ios.yml
+++ b/.github/workflows/test-maestro-ios.yml
@@ -110,6 +110,7 @@ jobs:
         if: needs.check.outputs.should-run == 'true'
         run: |
           cd examples/react-native/ios
+          bundle install
           bundle exec pod install
           cd ../../..
 


### PR DESCRIPTION
## 📱 Add Maestro iOS Test Workflow

Added iOS test workflow following the same pattern as Android test workflow.

### Changes

- **Added iOS test workflow** (`test-maestro-ios.yml`)
  - Build and test iOS app on macOS runner
  - Install CocoaPods dependencies
  - Build iOS app using xcodebuild
  - Install app on iOS simulator
  - Run Maestro tests
  - Check test results and fail workflow on test failure
  - Comment test results on PR

- **Consistency with Android workflow**
  - Same path filtering pattern
  - Same error message format
  - Same style guide (single quotes)

### Test Coverage

- iOS build of React Native example app
- Maestro E2E test execution
- Workflow failure on test failure