### PR TITLE
inspector FSD and metro proxy reconnect + cached Redux

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -188,6 +188,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@radix-ui/react-toast": "^1.2.15",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-query": "^5.90.12",
@@ -874,6 +875,8 @@
 
     "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A=="],
 
+    "@radix-ui/react-toast": ["@radix-ui/react-toast@1.2.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g=="],
+
     "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.8", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg=="],
 
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
@@ -1200,7 +1203,7 @@
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.141.0", "", {}, "sha512-CJrWtr6L9TVzEImm9S7dQINx+xJcYP/aDkIi6gnaWtIgbZs1pnzsE0yJc2noqXZ+yAOqLx3TBGpBEs9tS0P9/A=="],
 
-    "@tauri-apps/api": ["@tauri-apps/api@2.9.1", "", {}, "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw=="],
+    "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
     "@tauri-apps/cli": ["@tauri-apps/cli@2.9.6", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.9.6", "@tauri-apps/cli-darwin-x64": "2.9.6", "@tauri-apps/cli-linux-arm-gnueabihf": "2.9.6", "@tauri-apps/cli-linux-arm64-gnu": "2.9.6", "@tauri-apps/cli-linux-arm64-musl": "2.9.6", "@tauri-apps/cli-linux-riscv64-gnu": "2.9.6", "@tauri-apps/cli-linux-x64-gnu": "2.9.6", "@tauri-apps/cli-linux-x64-musl": "2.9.6", "@tauri-apps/cli-win32-arm64-msvc": "2.9.6", "@tauri-apps/cli-win32-ia32-msvc": "2.9.6", "@tauri-apps/cli-win32-x64-msvc": "2.9.6" }, "bin": { "tauri": "tauri.js" } }, "sha512-3xDdXL5omQ3sPfBfdC8fCtDKcnyV7OqyzQgfyT5P3+zY6lcPqIYKQBvUasNvppi21RSdfhy44ttvJmftb0PCDw=="],
 
@@ -3614,7 +3617,9 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@tauri-apps/plugin-http/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+    "@tauri-apps/plugin-clipboard-manager/@tauri-apps/api": ["@tauri-apps/api@2.9.1", "", {}, "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw=="],
+
+    "@tauri-apps/plugin-opener/@tauri-apps/api": ["@tauri-apps/api@2.9.1", "", {}, "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw=="],
 
     "@testing-library/dom/pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 

--- a/crates/server/src/socket_server/metro_proxy_handler/handler.rs
+++ b/crates/server/src/socket_server/metro_proxy_handler/handler.rs
@@ -20,6 +20,10 @@ use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
 /// CDP id used for inject Runtime.evaluate (reconnect); filter response so we don't forward to DevTools / 주입용 Runtime.evaluate(reconnect) id; 응답은 DevTools로 전달하지 않음
 const INJECT_RECONNECT_CDP_ID: i64 = 2147483646;
 
+/// Expression injected via Runtime.evaluate so RN app calls __ChromeRemoteDevToolsReconnect / RN 앱에서 __ChromeRemoteDevToolsReconnect 호출하도록 주입하는 표현식
+pub(super) const INJECT_RECONNECT_EXPRESSION: &str =
+    "typeof __ChromeRemoteDevToolsReconnect === 'function' && __ChromeRemoteDevToolsReconnect()";
+
 /// Handle Metro WebSocket proxy connection / Metro WebSocket 프록시 연결 처리
 /// Connects to Metro's WebSocket and relays messages bidirectionally,
 /// rewriting Debugger.scriptParsed URLs to go through our server's resource proxy.
@@ -112,12 +116,15 @@ pub async fn handle_metro_proxy_websocket(
     let (mut devtools_sink, mut devtools_stream) = ws.split();
     let (mut metro_sink, mut metro_stream) = metro_ws.split();
 
-    // Inject Runtime.evaluate in app to call reconnect so app connects to server (Redux/MMKV then work) / 앱에서 reconnect 호출하도록 Runtime.evaluate 주입 → 앱이 서버에 연결 (Redux/MMKV 동작)
+    // Inject Runtime.evaluate in app to call reconnect so app connects to server (Redux/MMKV then work) /
+    // 앱에서 reconnect 호출하도록 Runtime.evaluate 주입 → 앱이 서버에 연결 (Redux/MMKV 동작)
+    // Always send on new metro proxy connection (including Inspector refresh: new DevTools iframe = new connection) /
+    // 새 metro proxy 연결 시마다 전송 (Inspector 새로고침 포함: 새 DevTools iframe = 새 연결)
     let inject_reconnect = serde_json::json!({
         "id": INJECT_RECONNECT_CDP_ID,
         "method": "Runtime.evaluate",
         "params": {
-            "expression": "typeof __ChromeRemoteDevToolsReconnect === 'function' && __ChromeRemoteDevToolsReconnect()"
+            "expression": INJECT_RECONNECT_EXPRESSION
         }
     });
     if let Ok(inject_text) = serde_json::to_string(&inject_reconnect) {
@@ -151,6 +158,26 @@ pub async fn handle_metro_proxy_websocket(
             .map(|c| (Some(c.id.clone()), c.client_id.clone()))
             .unwrap_or((None, None))
     };
+
+    // When existing RN inspector is already connected (e.g. Inspector refresh), send inject again so app
+    // reconnects and Redux/AsyncStorage work / 기존 RN이 이미 연결된 경우(Inspector 새로고침) inject를 한 번 더 전송
+    if rn_connection_id.is_some() {
+        if let Ok(inject_text) = serde_json::to_string(&inject_reconnect) {
+            if metro_sink
+                .send(TungsteniteMessage::Text(inject_text))
+                .await
+                .is_err()
+            {
+                logger.log(
+                    LogType::Server,
+                    "metro-proxy",
+                    "Failed to send second inject reconnect (refresh path) to Metro",
+                    None,
+                    None,
+                );
+            }
+        }
+    }
 
     let devtool_entry = Arc::new(DevTools {
         id: metro_devtools_id.clone(),
@@ -191,6 +218,63 @@ pub async fn handle_metro_proxy_websocket(
                     }
                 }
             }
+        }
+
+        // Send cached Redux stores to this (new) DevTools so Redux/AsyncStorage panel works after refresh /
+        // 새로고침 후에도 Redux/AsyncStorage 패널이 동작하도록 캐시된 Redux store를 이 DevTools로 전송
+        if let Some(ref conn_id) = rn_connection_id {
+            let metro_sender = app_tx.clone();
+            let rn_manager_redux = rn_manager.clone();
+            let logger_redux = logger.clone();
+            let metro_id_redux = metro_devtools_id.clone();
+            let inspector_id_for_redux = conn_id.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+                let stores = rn_manager_redux
+                    .get_redux_stores(&inspector_id_for_redux)
+                    .await;
+                for store in &stores {
+                    let init_instance_msg = serde_json::json!({
+                        "method": "Redux.message",
+                        "params": {
+                            "type": "INIT_INSTANCE",
+                            "instanceId": store.instance_id,
+                            "source": "@devtools-page",
+                        }
+                    });
+                    if let Ok(json_str) = serde_json::to_string(&init_instance_msg) {
+                        let _ = metro_sender.send(json_str);
+                    }
+                    let init_msg = serde_json::json!({
+                        "method": "Redux.message",
+                        "params": {
+                            "type": "INIT",
+                            "instanceId": store.instance_id,
+                            "source": "@devtools-page",
+                            "name": store.name,
+                            "payload": store.payload,
+                            "maxAge": 50,
+                            "timestamp": store.timestamp,
+                        }
+                    });
+                    if let Ok(json_str) = serde_json::to_string(&init_msg) {
+                        let _ = metro_sender.send(json_str);
+                    }
+                }
+                if !stores.is_empty() {
+                    logger_redux.log(
+                        LogType::Server,
+                        "metro-proxy",
+                        &format!(
+                            "Sent {} cached Redux store(s) to new DevTools ({})",
+                            stores.len(),
+                            metro_id_redux
+                        ),
+                        None,
+                        None,
+                    );
+                }
+            });
         }
     } else {
         logger.log(
@@ -412,4 +496,28 @@ pub async fn handle_metro_proxy_websocket(
         None,
         None,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{INJECT_RECONNECT_CDP_ID, INJECT_RECONNECT_EXPRESSION};
+
+    /// Inject payload must be Runtime.evaluate with expression that calls __ChromeRemoteDevToolsReconnect /
+    /// inject 페이로드는 Runtime.evaluate이며 표현식이 __ChromeRemoteDevToolsReconnect를 호출해야 함
+    #[test]
+    fn inject_reconnect_payload_shape() {
+        let inject = serde_json::json!({
+            "id": INJECT_RECONNECT_CDP_ID,
+            "method": "Runtime.evaluate",
+            "params": {
+                "expression": INJECT_RECONNECT_EXPRESSION
+            }
+        });
+        assert_eq!(inject["method"], "Runtime.evaluate");
+        let expr = inject["params"]["expression"].as_str().unwrap();
+        assert!(
+            expr.contains("__ChromeRemoteDevToolsReconnect"),
+            "expression must call __ChromeRemoteDevToolsReconnect for RN app reconnect"
+        );
+    }
 }

--- a/examples/react-native/src/App.tsx
+++ b/examples/react-native/src/App.tsx
@@ -16,6 +16,7 @@ import {
   registerMMKVDevTools,
   registerAsyncStorageDevTools,
   type AsyncStorageType,
+  type MMKVStorageInput,
 } from '@ohah/chrome-remote-devtools-inspector-react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getUniqueId } from 'react-native-device-info';
@@ -39,14 +40,16 @@ function App() {
 
   // Register MMKV DevTools / MMKV DevTools 등록
   // v4 is default, v3 is for legacy support / v4가 기본, v3는 하위 호환용
+  // Cast to MMKVStorageInput so v3 getBuffer (ArrayBufferLike) is accepted / v3 getBuffer(ArrayBufferLike) 허용을 위해 MMKVStorageInput 단언
   useEffect(() => {
     try {
-      registerMMKVDevTools({
+      const storages: MMKVStorageInput = {
         user: userStorage, // v4
         cache: cacheStorage, // v4
         default: defaultStorage, // v4
         legacy: legacyStorage, // v3 (legacy support)
-      });
+      };
+      registerMMKVDevTools(storages);
     } catch (error) {
       console.error('[App] Error registering MMKV DevTools:', error);
       // Don't block app startup / 앱 시작을 막지 않음

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-query": "^5.90.12",

--- a/packages/inspector/src/app/providers/index.tsx
+++ b/packages/inspector/src/app/providers/index.tsx
@@ -1,4 +1,5 @@
 // App providers / 앱 프로바이더
+import * as Toast from '@radix-ui/react-toast';
 import { RouterProvider } from '@tanstack/react-router';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -8,9 +9,12 @@ import { queryClient } from '@/shared/api/query-client';
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider delayDuration={300}>
-        <RouterProvider router={router} />
-      </TooltipProvider>
+      <Toast.Provider duration={3000} label="Notification">
+        <TooltipProvider delayDuration={300}>
+          <RouterProvider router={router} />
+        </TooltipProvider>
+        <Toast.Viewport className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[1002] flex flex-col gap-2 max-w-[90vw] outline-none" />
+      </Toast.Provider>
     </QueryClientProvider>
   );
 }

--- a/packages/inspector/src/features/tabs-visibility/index.ts
+++ b/packages/inspector/src/features/tabs-visibility/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Tabs visibility feature / 탭 표시 여부 기능
+ */
+export { getTabsVisibility, useTabsVisibility } from './model/use-tabs-visibility';
+export { TabVisibilityToggle } from './ui/tab-visibility-toggle';

--- a/packages/inspector/src/features/tabs-visibility/model/__tests__/use-tabs-visibility.test.ts
+++ b/packages/inspector/src/features/tabs-visibility/model/__tests__/use-tabs-visibility.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tabs visibility model tests / 탭 표시 모델 테스트
+ * Covers getTabsVisibility and useTabsVisibility / getTabsVisibility 및 useTabsVisibility 검증
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+import { getTabsVisibility, useTabsVisibility } from '../use-tabs-visibility';
+
+const STORAGE_KEY = 'tabs-visible';
+
+describe('tabs-visibility', () => {
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  describe('getTabsVisibility', () => {
+    test('returns true when key is unset / 미설정 시 true', () => {
+      expect(getTabsVisibility()).toBe(true);
+    });
+
+    test('returns true when key is "true" / "true"일 때 true', () => {
+      localStorage.setItem(STORAGE_KEY, 'true');
+      expect(getTabsVisibility()).toBe(true);
+    });
+
+    test('returns false when key is "false" / "false"일 때 false', () => {
+      localStorage.setItem(STORAGE_KEY, 'false');
+      expect(getTabsVisibility()).toBe(false);
+    });
+
+    test('returns true for any other value / 그 외 값은 true', () => {
+      localStorage.setItem(STORAGE_KEY, '');
+      expect(getTabsVisibility()).toBe(true);
+      localStorage.setItem(STORAGE_KEY, '1');
+      expect(getTabsVisibility()).toBe(true);
+    });
+  });
+
+  describe('useTabsVisibility', () => {
+    test('initial showTabs matches getTabsVisibility / 초기값이 getTabsVisibility와 일치', () => {
+      localStorage.setItem(STORAGE_KEY, 'true');
+      const { result } = renderHook(() => useTabsVisibility());
+      expect(result.current.showTabs).toBe(true);
+
+      localStorage.setItem(STORAGE_KEY, 'false');
+      const { result: result2 } = renderHook(() => useTabsVisibility());
+      expect(result2.current.showTabs).toBe(false);
+    });
+
+    test('toggle updates showTabs and localStorage / toggle 시 showTabs와 localStorage 갱신', () => {
+      localStorage.setItem(STORAGE_KEY, 'true');
+      const { result } = renderHook(() => useTabsVisibility());
+      expect(result.current.showTabs).toBe(true);
+
+      act(() => {
+        result.current.toggle();
+      });
+      expect(result.current.showTabs).toBe(false);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe('false');
+
+      act(() => {
+        result.current.toggle();
+      });
+      expect(result.current.showTabs).toBe(true);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+    });
+
+    test('toggle dispatches tabs-visibility-change event / toggle 시 tabs-visibility-change 이벤트 발생', () => {
+      let received: { visible: boolean } | null = null;
+      const handler = (e: Event) => {
+        received = (e as CustomEvent<{ visible: boolean }>).detail;
+      };
+      window.addEventListener('tabs-visibility-change', handler);
+
+      localStorage.setItem(STORAGE_KEY, 'true');
+      const { result } = renderHook(() => useTabsVisibility());
+
+      act(() => {
+        result.current.toggle();
+      });
+      expect(received).not.toBeNull();
+      expect(received!.visible).toBe(false);
+
+      act(() => {
+        result.current.toggle();
+      });
+      expect(received!.visible).toBe(true);
+
+      window.removeEventListener('tabs-visibility-change', handler);
+    });
+  });
+});

--- a/packages/inspector/src/features/tabs-visibility/model/use-tabs-visibility.ts
+++ b/packages/inspector/src/features/tabs-visibility/model/use-tabs-visibility.ts
@@ -1,0 +1,39 @@
+/**
+ * Tabs visibility state and toggle / 탭 표시 상태 및 토글
+ * Syncs with localStorage and dispatches tabs-visibility-change event /
+ * localStorage와 동기화하고 tabs-visibility-change 이벤트 발생
+ */
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'tabs-visible';
+
+/**
+ * Read tabs visibility from localStorage / localStorage에서 탭 표시 여부 읽기
+ */
+export function getTabsVisibility(): boolean {
+  if (typeof window === 'undefined') return true;
+  const visible = localStorage.getItem(STORAGE_KEY);
+  return visible !== 'false';
+}
+
+/**
+ * Hook for tabs visibility state and toggle / 탭 표시 상태 및 토글 훅
+ */
+export function useTabsVisibility(): { showTabs: boolean; toggle: () => void } {
+  const [showTabs, setShowTabs] = useState(getTabsVisibility);
+
+  useEffect(() => {
+    setShowTabs(getTabsVisibility());
+  }, []);
+
+  const toggle = useCallback(() => {
+    const newValue = !getTabsVisibility();
+    setShowTabs(newValue);
+    localStorage.setItem(STORAGE_KEY, String(newValue));
+    window.dispatchEvent(
+      new CustomEvent('tabs-visibility-change', { detail: { visible: newValue } })
+    );
+  }, []);
+
+  return { showTabs, toggle };
+}

--- a/packages/inspector/src/features/tabs-visibility/ui/tab-visibility-toggle.tsx
+++ b/packages/inspector/src/features/tabs-visibility/ui/tab-visibility-toggle.tsx
@@ -1,0 +1,31 @@
+/**
+ * Tab visibility toggle button / 탭 표시/숨김 토글 버튼
+ */
+import { Eye, EyeOff } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useTabsVisibility } from '../model/use-tabs-visibility';
+
+export function TabVisibilityToggle() {
+  const { showTabs, toggle } = useTabsVisibility();
+
+  return (
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={toggle}
+          className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50 ml-2"
+          aria-label={showTabs ? 'Hide tabs' : 'Show tabs'}
+          aria-pressed={showTabs}
+        >
+          {showTabs ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="z-[1001]">
+        <p>{showTabs ? 'Hide tabs' : 'Show tabs'}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/inspector/src/pages/devtools/index.tsx
+++ b/packages/inspector/src/pages/devtools/index.tsx
@@ -13,7 +13,7 @@ import {
 import { useServerUrl } from '@/shared/lib';
 import { Tabs, type Tab } from '@/components/tabs';
 import { Smartphone, Globe, Wifi } from 'lucide-react';
-import { getTabsVisibility } from '@/routes/__root';
+import { getTabsVisibility } from '@/features/tabs-visibility';
 import type { Client } from '@/entities/client';
 
 /** One tab per device (key); RN uses deviceId, web use id / 기기(key)당 탭 하나; RN은 deviceId, 웹은 id */

--- a/packages/inspector/src/routes/__root.tsx
+++ b/packages/inspector/src/routes/__root.tsx
@@ -1,293 +1,35 @@
-// Root route
-import { createRootRoute, Outlet, useNavigate } from '@tanstack/react-router';
-import { useCallback, useEffect, useState } from 'react';
-import {
-  RefreshCw,
-  Minus,
-  Maximize2,
-  X,
-  Eye,
-  EyeOff,
-  Home,
-  Settings,
-  Terminal,
-} from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+// Root route / 루트 라우트
+import { createRootRoute, Outlet } from '@tanstack/react-router';
+import { useEffect } from 'react';
 import { useClientsListSSE } from '@/entities/client';
 import { SettingsModal } from '@/features/settings';
-import {
-  useSettingsModalStore,
-  useOpenSettings,
-  getServerUrl,
-  parseServerUrlToBind,
-} from '@/shared/lib';
+import { getServerUrl, parseServerUrlToBind, useSettingsModalStore } from '@/shared/lib';
+import { TitleBar } from '@/widgets/title-bar';
 
-// Tab visibility toggle component / 탭 표시/숨김 토글 컴포넌트
-function TabVisibilityToggle() {
-  const [showTabs, setShowTabs] = useState(true);
-
-  // Load tab visibility state from localStorage / localStorage에서 탭 표시 상태 로드
-  useEffect(() => {
-    const savedShowTabs = localStorage.getItem('tabs-visible');
-    if (savedShowTabs !== null) {
-      setShowTabs(savedShowTabs === 'true');
-    }
-  }, []);
-
-  // Toggle tab visibility / 탭 표시/숨김 토글
-  const handleToggle = () => {
-    const newValue = !showTabs;
-    setShowTabs(newValue);
-    localStorage.setItem('tabs-visible', String(newValue));
-    // Dispatch custom event to notify other components / 다른 컴포넌트에 알리기 위한 커스텀 이벤트 발생
-    window.dispatchEvent(
-      new CustomEvent('tabs-visibility-change', { detail: { visible: newValue } })
-    );
-  };
-
-  return (
-    <Tooltip delayDuration={300}>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={handleToggle}
-          className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50 ml-2"
-          aria-label={showTabs ? 'Hide tabs' : 'Show tabs'}
-          aria-pressed={showTabs}
-        >
-          {showTabs ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" className="z-[1001]">
-        <p>{showTabs ? 'Hide tabs' : 'Show tabs'}</p>
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-// Title bar component
-function TitleBar() {
-  const openSettings = useOpenSettings();
-  const [appWindow, setAppWindow] = useState<ReturnType<
-    typeof import('@tauri-apps/api/window').getCurrentWindow
-  > | null>(null);
-  const navigate = useNavigate();
-  const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
-
-  useEffect(() => {
-    if (isTauri) {
-      import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
-        setAppWindow(getCurrentWindow());
-      });
-    }
-  }, []);
-
-  const handleHome = useCallback(() => {
-    navigate({ to: '/' });
-  }, [navigate]);
-
-  const handleRefresh = () => {
-    window.location.reload();
-  };
-
-  const handleMinimize = () => {
-    if (appWindow) {
-      void appWindow.minimize();
-    }
-  };
-
-  const handleMaximize = () => {
-    if (appWindow) {
-      void appWindow.toggleMaximize();
-    }
-  };
-
-  const handleClose = () => {
-    if (appWindow) {
-      void appWindow.close();
-    }
-  };
-
-  const serverPort = parseServerUrlToBind(getServerUrl()).port;
-  // Run adb reverse for Server URL port (Settings) / 설정(Server URL) 포트로 adb reverse 실행
-  const handleAdbReverse = useCallback(() => {
-    if (!isTauri) return;
-    import('@tauri-apps/api/core')
-      .then(({ invoke }) =>
-        invoke<{ success: boolean; message: string }>('adb_reverse_port', { port: serverPort })
-      )
-      .then((result) => {
-        if (result.success) {
-          window.alert(`adb reverse\n\n${result.message}`);
-        } else {
-          window.alert(`adb reverse failed\n\n${result.message}`);
-        }
-      })
-      .catch((err) => {
-        const msg = typeof err === 'string' ? err : (err?.message ?? String(err));
-        window.alert(`adb reverse error\n\n${msg}`);
-      });
-  }, [isTauri, serverPort]);
-
-  return (
-    <div className="fixed top-0 left-0 right-0 z-[1000] h-[35px] bg-gray-700 border-b border-gray-600 select-none grid grid-cols-[1fr_max-content]">
-      <div
-        className="titlebar-drag-region flex items-center"
-        data-tauri-drag-region={isTauri ? true : undefined}
-      >
-        {/* Home button / 홈 버튼 */}
-        <Tooltip delayDuration={300}>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleHome}
-              className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50 ml-2"
-              aria-label="Go to home"
-            >
-              <Home className="w-3.5 h-3.5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" className="z-[1001]">
-            <p>Go to home</p>
-          </TooltipContent>
-        </Tooltip>
-        {/* Tab visibility toggle (always show in Tauri) / 탭 표시/숨김 토글 (Tauri에서 항상 표시) */}
-        {isTauri && <TabVisibilityToggle />}
-      </div>
-      {isTauri && (
-        <div className="flex items-center gap-2">
-          {/* adb reverse for Server URL port (Settings) / 설정 Server URL 포트로 adb reverse */}
-          <Tooltip delayDuration={300}>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleAdbReverse}
-                className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50"
-                aria-label={`Run adb reverse for port ${serverPort}`}
-              >
-                <Terminal className="w-3.5 h-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="z-[1001]">
-              <p>Run adb reverse tcp:{serverPort} (Settings Server URL port)</p>
-            </TooltipContent>
-          </Tooltip>
-          {/* Host/Settings button (right side of title bar) / 타이틀바 우측 호스트 설정 버튼 */}
-          <Tooltip delayDuration={300}>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={openSettings}
-                className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50"
-                aria-label="Host settings"
-              >
-                <Settings className="w-3.5 h-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="z-[1001]">
-              <p>Host settings (Server URL, Metro URL)</p>
-            </TooltipContent>
-          </Tooltip>
-          {appWindow && (
-            <div className="titlebar-controls flex">
-              {/* Refresh button / 새로고침 버튼 */}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
-                    onClick={handleRefresh}
-                    aria-label="Refresh"
-                  >
-                    <RefreshCw className="w-3.5 h-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="z-[1001]">
-                  <p>Refresh</p>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
-                    onClick={handleMinimize}
-                    aria-label="Minimize"
-                  >
-                    <Minus className="w-3.5 h-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="z-[1001]">
-                  <p>Minimize</p>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
-                    onClick={handleMaximize}
-                    aria-label="Maximize"
-                  >
-                    <Maximize2 className="w-3.5 h-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="z-[1001]">
-                  <p>Maximize</p>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-red-500 hover:text-white"
-                    onClick={handleClose}
-                    aria-label="Close"
-                  >
-                    <X className="w-3.5 h-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="z-[1001]">
-                  <p>Close</p>
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// Root component / 루트 컴포넌트
 function RootComponent() {
   const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
   const showTitleBar = isTauri;
-  // Only Root subscribes to isSettingsOpen → only Root re-renders when modal toggles / 모달 토글 시 Root만 리렌더
   const isSettingsOpen = useSettingsModalStore((s) => s.isSettingsOpen);
   const closeSettings = useSettingsModalStore((s) => s.closeSettings);
 
   // Start embedded server on port from Inspector Server URL when running in Tauri /
   // Tauri 실행 시 인스펙터 Server URL 설정의 포트로 내장 서버 시작
+  // Only start if not already running so refresh does not restart server and break Metro proxy WS /
+  // 이미 실행 중이면 시작하지 않아 새로고침 시 서버 재시작으로 Metro proxy WS 끊김 방지
   useEffect(() => {
     if (!isTauri) return;
     const url = getServerUrl();
     const { port, host } = parseServerUrlToBind(url);
     import('@tauri-apps/api/core')
-      .then(({ invoke }) => invoke('start_server', { port, host }))
+      .then(({ invoke }) =>
+        invoke<boolean>('is_server_running').then((running) => {
+          if (running) return;
+          return invoke('start_server', { port, host });
+        })
+      )
       .catch((e) => console.error('[inspector] Failed to start embedded server:', e));
   }, [isTauri]);
 
-  // Subscribe to client list SSE for live updates / 클라이언트 목록 실시간 갱신을 위한 SSE 구독
   useClientsListSSE();
 
   return (
@@ -304,9 +46,3 @@ function RootComponent() {
 export const Route = createRootRoute({
   component: RootComponent,
 });
-
-// Export tab visibility getter function / 탭 표시 상태를 가져오는 함수 export
-export function getTabsVisibility(): boolean {
-  const visible = localStorage.getItem('tabs-visible');
-  return visible !== 'false'; // Default to true / 기본값은 true
-}

--- a/packages/inspector/src/routes/index.tsx
+++ b/packages/inspector/src/routes/index.tsx
@@ -8,7 +8,7 @@ import { useServerUrl } from '@/shared/lib';
 import { Smartphone, Globe, Upload, Wifi } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tabs, type Tab } from '@/components/tabs';
-import { getTabsVisibility } from './__root';
+import { getTabsVisibility } from '@/features/tabs-visibility';
 import { useOpenSettings } from '@/shared/lib';
 
 export const Route = createFileRoute('/')({

--- a/packages/inspector/src/shared/lib/index.ts
+++ b/packages/inspector/src/shared/lib/index.ts
@@ -10,6 +10,7 @@ export {
 } from './constants';
 export {
   getServerUrl,
+  getMetroPort,
   setServerUrl,
   resetServerUrl,
   useServerUrl,

--- a/packages/inspector/src/shared/lib/server-url.ts
+++ b/packages/inspector/src/shared/lib/server-url.ts
@@ -88,12 +88,29 @@ export function parseServerUrlToBind(url: string): { host: string; port: number 
  * @returns Server URL (default http://localhost:8080 when not set) / 서버 URL (미설정 시 기본값)
  */
 const DEFAULT_SERVER_URL = 'http://localhost:8080';
+const DEFAULT_METRO_PORT = 8081;
 
 export function getServerUrl(): string {
   if (typeof window !== 'undefined' && import.meta.env.VITE_SERVER_URL) {
     return import.meta.env.VITE_SERVER_URL as string;
   }
   return useServerUrlStore.getState().getServerUrl() ?? DEFAULT_SERVER_URL;
+}
+
+/**
+ * Get Metro URL port for adb reverse (Server URL and Metro URL both need reverse on Android) /
+ * adb reverse용 Metro 포트 (Android에서 서버·Metro 둘 다 접근하려면 둘 다 reverse 필요)
+ * @returns Port number (default 8081 when not set or invalid) / 포트 번호 (미설정·무효 시 8081)
+ */
+export function getMetroPort(): number {
+  try {
+    const url = useServerUrlStore.getState().getMetroUrl() ?? 'http://localhost:8081';
+    const u = new URL(url);
+    const port = u.port ? parseInt(u.port, 10) : DEFAULT_METRO_PORT;
+    return Number.isNaN(port) || port <= 0 ? DEFAULT_METRO_PORT : port;
+  } catch {
+    return DEFAULT_METRO_PORT;
+  }
 }
 
 /**

--- a/packages/inspector/src/widgets/title-bar/index.ts
+++ b/packages/inspector/src/widgets/title-bar/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Title bar widget / 타이틀바 위젯
+ */
+export { TitleBar } from './ui/TitleBar';

--- a/packages/inspector/src/widgets/title-bar/ui/TitleBar.tsx
+++ b/packages/inspector/src/widgets/title-bar/ui/TitleBar.tsx
@@ -1,0 +1,206 @@
+/**
+ * Title bar widget (Tauri) / 타이틀바 위젯 (Tauri)
+ * Composite: home, tabs visibility, adb reverse, settings, window controls
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { RefreshCw, Minus, Maximize2, X, Home, Settings, Terminal } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { TabVisibilityToggle } from '@/features/tabs-visibility';
+import { useOpenSettings } from '@/shared/lib';
+import { getServerUrl, parseServerUrlToBind } from '@/shared/lib';
+
+export function TitleBar() {
+  const openSettings = useOpenSettings();
+  const [appWindow, setAppWindow] = useState<ReturnType<
+    typeof import('@tauri-apps/api/window').getCurrentWindow
+  > | null>(null);
+  const navigate = useNavigate();
+  const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+
+  useEffect(() => {
+    if (isTauri) {
+      import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
+        setAppWindow(getCurrentWindow());
+      });
+    }
+  }, [isTauri]);
+
+  const handleHome = useCallback(() => {
+    navigate({ to: '/' });
+  }, [navigate]);
+
+  const handleRefresh = () => {
+    window.location.reload();
+  };
+
+  const handleMinimize = () => {
+    if (appWindow) {
+      void appWindow.minimize();
+    }
+  };
+
+  const handleMaximize = () => {
+    if (appWindow) {
+      void appWindow.toggleMaximize();
+    }
+  };
+
+  const handleClose = () => {
+    if (appWindow) {
+      void appWindow.close();
+    }
+  };
+
+  const serverPort = parseServerUrlToBind(getServerUrl()).port;
+  const handleAdbReverse = useCallback(() => {
+    if (!isTauri) return;
+    import('@tauri-apps/api/core')
+      .then(({ invoke }) =>
+        invoke<{ success: boolean; message: string }>('adb_reverse_port', { port: serverPort })
+      )
+      .then((result) => {
+        if (result.success) {
+          window.alert(`adb reverse\n\n${result.message}`);
+        } else {
+          window.alert(`adb reverse failed\n\n${result.message}`);
+        }
+      })
+      .catch((err) => {
+        const msg = typeof err === 'string' ? err : (err?.message ?? String(err));
+        window.alert(`adb reverse error\n\n${msg}`);
+      });
+  }, [isTauri, serverPort]);
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-[1000] h-[35px] bg-gray-700 border-b border-gray-600 select-none grid grid-cols-[1fr_max-content]">
+      <div
+        className="titlebar-drag-region flex items-center"
+        data-tauri-drag-region={isTauri ? true : undefined}
+      >
+        <Tooltip delayDuration={300}>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleHome}
+              className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50 ml-2"
+              aria-label="Go to home"
+            >
+              <Home className="w-3.5 h-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="z-[1001]">
+            <p>Go to home</p>
+          </TooltipContent>
+        </Tooltip>
+        {isTauri && <TabVisibilityToggle />}
+      </div>
+      {isTauri && (
+        <div className="flex items-center gap-2">
+          <Tooltip delayDuration={300}>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleAdbReverse}
+                className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50"
+                aria-label={`Run adb reverse for port ${serverPort}`}
+              >
+                <Terminal className="w-3.5 h-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="z-[1001]">
+              <p>Run adb reverse tcp:{serverPort} (Settings Server URL port)</p>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip delayDuration={300}>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={openSettings}
+                className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50"
+                aria-label="Host settings"
+              >
+                <Settings className="w-3.5 h-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="z-[1001]">
+              <p>Host settings (Server URL, Metro URL)</p>
+            </TooltipContent>
+          </Tooltip>
+          {appWindow && (
+            <div className="titlebar-controls flex">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
+                    onClick={handleRefresh}
+                    aria-label="Refresh"
+                  >
+                    <RefreshCw className="w-3.5 h-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="z-[1001]">
+                  <p>Refresh</p>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
+                    onClick={handleMinimize}
+                    aria-label="Minimize"
+                  >
+                    <Minus className="w-3.5 h-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="z-[1001]">
+                  <p>Minimize</p>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
+                    onClick={handleMaximize}
+                    aria-label="Maximize"
+                  >
+                    <Maximize2 className="w-3.5 h-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="z-[1001]">
+                  <p>Maximize</p>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-red-500 hover:text-white"
+                    onClick={handleClose}
+                    aria-label="Close"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="z-[1001]">
+                  <p>Close</p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/inspector/src/widgets/title-bar/ui/TitleBar.tsx
+++ b/packages/inspector/src/widgets/title-bar/ui/TitleBar.tsx
@@ -2,6 +2,7 @@
  * Title bar widget (Tauri) / 타이틀바 위젯 (Tauri)
  * Composite: home, tabs visibility, adb reverse, settings, window controls
  */
+import * as Toast from '@radix-ui/react-toast';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { RefreshCw, Minus, Maximize2, X, Home, Settings, Terminal } from 'lucide-react';
@@ -9,10 +10,14 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { TabVisibilityToggle } from '@/features/tabs-visibility';
 import { useOpenSettings } from '@/shared/lib';
-import { getServerUrl, parseServerUrlToBind } from '@/shared/lib';
+import { getServerUrl, getMetroPort, parseServerUrlToBind } from '@/shared/lib';
+
+/** Toast state for adb reverse result / adb reverse 결과용 토스트 상태 */
+type ToastState = { message: string; type: 'success' | 'error' } | null;
 
 export function TitleBar() {
   const openSettings = useOpenSettings();
+  const [toast, setToast] = useState<ToastState>(null);
   const [appWindow, setAppWindow] = useState<ReturnType<
     typeof import('@tauri-apps/api/window').getCurrentWindow
   > | null>(null);
@@ -54,153 +59,187 @@ export function TitleBar() {
   };
 
   const serverPort = parseServerUrlToBind(getServerUrl()).port;
+  const metroPort = getMetroPort();
   const handleAdbReverse = useCallback(() => {
     if (!isTauri) return;
+    const ports = serverPort === metroPort ? [serverPort] : [serverPort, metroPort];
     import('@tauri-apps/api/core')
       .then(({ invoke }) =>
-        invoke<{ success: boolean; message: string }>('adb_reverse_port', { port: serverPort })
+        Promise.all(
+          ports.map((port) =>
+            invoke<{ success: boolean; message: string }>('adb_reverse_port', { port })
+          )
+        )
       )
-      .then((result) => {
-        if (result.success) {
-          window.alert(`adb reverse\n\n${result.message}`);
-        } else {
-          window.alert(`adb reverse failed\n\n${result.message}`);
-        }
+      .then((results) => {
+        const allOk = results.every((r) => r.success);
+        const summary =
+          ports.length === 1
+            ? (results[0]?.message ?? `adb reverse tcp:${serverPort} succeeded.`)
+            : allOk
+              ? `adb reverse tcp:${serverPort}, tcp:${metroPort} succeeded.`
+              : results
+                  .filter((r) => !r.success)
+                  .map((r) => r.message)
+                  .join(' ') || 'adb reverse failed.';
+        setToast({ message: summary, type: allOk ? 'success' : 'error' });
       })
       .catch((err) => {
         const msg = typeof err === 'string' ? err : (err?.message ?? String(err));
-        window.alert(`adb reverse error\n\n${msg}`);
+        setToast({ message: msg, type: 'error' });
       });
-  }, [isTauri, serverPort]);
+  }, [isTauri, serverPort, metroPort]);
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-[1000] h-[35px] bg-gray-700 border-b border-gray-600 select-none grid grid-cols-[1fr_max-content]">
-      <div
-        className="titlebar-drag-region flex items-center"
-        data-tauri-drag-region={isTauri ? true : undefined}
-      >
-        <Tooltip delayDuration={300}>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleHome}
-              className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50 ml-2"
-              aria-label="Go to home"
-            >
-              <Home className="w-3.5 h-3.5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" className="z-[1001]">
-            <p>Go to home</p>
-          </TooltipContent>
-        </Tooltip>
-        {isTauri && <TabVisibilityToggle />}
-      </div>
-      {isTauri && (
-        <div className="flex items-center gap-2">
+    <>
+      <div className="fixed top-0 left-0 right-0 z-[1000] h-[35px] bg-gray-700 border-b border-gray-600 select-none grid grid-cols-[1fr_max-content]">
+        <div
+          className="titlebar-drag-region flex items-center"
+          data-tauri-drag-region={isTauri ? true : undefined}
+        >
           <Tooltip delayDuration={300}>
             <TooltipTrigger asChild>
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={handleAdbReverse}
-                className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50"
-                aria-label={`Run adb reverse for port ${serverPort}`}
+                onClick={handleHome}
+                className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50 ml-2"
+                aria-label="Go to home"
               >
-                <Terminal className="w-3.5 h-3.5" />
+                <Home className="w-3.5 h-3.5" />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom" className="z-[1001]">
-              <p>Run adb reverse tcp:{serverPort} (Settings Server URL port)</p>
+              <p>Go to home</p>
             </TooltipContent>
           </Tooltip>
-          <Tooltip delayDuration={300}>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={openSettings}
-                className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50"
-                aria-label="Host settings"
-              >
-                <Settings className="w-3.5 h-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="z-[1001]">
-              <p>Host settings (Server URL, Metro URL)</p>
-            </TooltipContent>
-          </Tooltip>
-          {appWindow && (
-            <div className="titlebar-controls flex">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
-                    onClick={handleRefresh}
-                    aria-label="Refresh"
-                  >
-                    <RefreshCw className="w-3.5 h-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="z-[1001]">
-                  <p>Refresh</p>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
-                    onClick={handleMinimize}
-                    aria-label="Minimize"
-                  >
-                    <Minus className="w-3.5 h-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="z-[1001]">
-                  <p>Minimize</p>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
-                    onClick={handleMaximize}
-                    aria-label="Maximize"
-                  >
-                    <Maximize2 className="w-3.5 h-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="z-[1001]">
-                  <p>Maximize</p>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-red-500 hover:text-white"
-                    onClick={handleClose}
-                    aria-label="Close"
-                  >
-                    <X className="w-3.5 h-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="z-[1001]">
-                  <p>Close</p>
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          )}
+          {isTauri && <TabVisibilityToggle />}
         </div>
+        {isTauri && (
+          <div className="flex items-center gap-2">
+            <Tooltip delayDuration={300}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleAdbReverse}
+                  className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50"
+                  aria-label={`Run adb reverse for ports ${serverPort}, ${metroPort}`}
+                >
+                  <Terminal className="w-3.5 h-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="z-[1001]">
+                <p>
+                  Run adb reverse for tcp:{serverPort} (Server), tcp:{metroPort} (Metro)
+                </p>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip delayDuration={300}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={openSettings}
+                  className="titlebar-nav-button cursor-pointer h-auto px-2.5 py-1.5 rounded text-xs transition-all text-gray-400 hover:text-gray-200 hover:bg-gray-600/50"
+                  aria-label="Host settings"
+                >
+                  <Settings className="w-3.5 h-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="z-[1001]">
+                <p>Host settings (Server URL, Metro URL)</p>
+              </TooltipContent>
+            </Tooltip>
+            {appWindow && (
+              <div className="titlebar-controls flex">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
+                      onClick={handleRefresh}
+                      aria-label="Refresh"
+                    >
+                      <RefreshCw className="w-3.5 h-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="z-[1001]">
+                    <p>Refresh</p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
+                      onClick={handleMinimize}
+                      aria-label="Minimize"
+                    >
+                      <Minus className="w-3.5 h-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="z-[1001]">
+                    <p>Minimize</p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-white/10"
+                      onClick={handleMaximize}
+                      aria-label="Maximize"
+                    >
+                      <Maximize2 className="w-3.5 h-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="z-[1001]">
+                    <p>Maximize</p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-[35px] w-[35px] bg-transparent text-gray-400 hover:bg-red-500 hover:text-white"
+                      onClick={handleClose}
+                      aria-label="Close"
+                    >
+                      <X className="w-3.5 h-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="z-[1001]">
+                    <p>Close</p>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      {/* Radix Toast for adb reverse result / adb reverse 결과 토스트 */}
+      {toast && (
+        <Toast.Root
+          type="foreground"
+          duration={3000}
+          open={!!toast}
+          onOpenChange={(open) => !open && setToast(null)}
+          className="rounded-lg shadow-lg px-4 py-2 text-sm text-white max-w-[90vw] line-clamp-2 data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-bottom-full"
+          style={{
+            backgroundColor: toast.type === 'success' ? '#22c55e' : '#ef4444',
+          }}
+        >
+          <Toast.Description>
+            {toast.type === 'success' ? '✓ ' : '✗ '}
+            {toast.message}
+          </Toast.Description>
+        </Toast.Root>
       )}
-    </div>
+    </>
   );
 }

--- a/packages/react-native-inspector/src/index.ts
+++ b/packages/react-native-inspector/src/index.ts
@@ -219,7 +219,7 @@ export { ChromeRemoteDevToolsInspectorProvider } from './Provider';
 export type { ChromeRemoteDevToolsInspectorProviderProps } from './Provider';
 
 export { registerMMKVDevTools, unregisterMMKVDevTools } from './mmkv';
-export type { MMKVEntry, MMKVEntryType, MMKVEntryValue } from './mmkv/types';
+export type { MMKVEntry, MMKVEntryType, MMKVEntryValue, MMKVStorageInput } from './mmkv/types';
 
 export { registerAsyncStorageDevTools, unregisterAsyncStorageDevTools } from './async-storage';
 export type {

--- a/packages/react-native-inspector/src/mmkv/index.ts
+++ b/packages/react-native-inspector/src/mmkv/index.ts
@@ -49,9 +49,11 @@ export function setMMKVCDPSender(
 
 /**
  * Mark connection as ready / 연결 준비 완료 표시
+ * Sends all MMKV snapshots so DevTools that already opened the MMKV tab get data (avoids race where enable was sent before connection) / 이미 MMKV 탭을 연 DevTools가 데이터를 받도록 스냅샷 전송 (연결 전 enable 수신 시 누락 방지)
  */
 export function setMMKVConnectionReady(): void {
   isConnected = true;
+  sendAllSnapshots();
 }
 
 /**

--- a/packages/react-native-inspector/src/mmkv/types.ts
+++ b/packages/react-native-inspector/src/mmkv/types.ts
@@ -1,12 +1,15 @@
 // MMKV types / MMKV 타입
 
+// Buffer type accepted from MMKV (ArrayBufferLike includes ArrayBuffer and SharedArrayBuffer in some runtimes) / MMKV에서 허용하는 버퍼 타입 (일부 런타임에서 SharedArrayBuffer 반환)
+type MMKVBuffer = ArrayBufferLike;
+
 // MMKV v4 type (default, has 'remove' method) / MMKV v4 타입 (기본, 'remove' 메서드 있음)
 type MMKVV4 = {
   set(key: string, value: boolean | string | number | ArrayBuffer): void;
   getBoolean(key: string): boolean | undefined;
   getString(key: string): string | undefined;
   getNumber(key: string): number | undefined;
-  getBuffer(key: string): ArrayBuffer | undefined;
+  getBuffer(key: string): MMKVBuffer | undefined;
   remove(key: string): boolean;
   getAllKeys(): string[];
   addOnValueChangedListener(callback: (key: string) => void): { remove: () => void };
@@ -19,7 +22,7 @@ type MMKVV3 = {
   getBoolean(key: string): boolean | undefined;
   getString(key: string): string | undefined;
   getNumber(key: string): number | undefined;
-  getBuffer(key: string): ArrayBuffer | undefined;
+  getBuffer(key: string): MMKVBuffer | undefined;
   delete(key: string): void;
   getAllKeys(): string[];
   addOnValueChangedListener(callback: (key: string) => void): { remove: () => void };
@@ -45,7 +48,7 @@ type MMKVStorageInstance = {
   getBoolean(key: string): boolean | undefined;
   getString(key: string): string | undefined;
   getNumber(key: string): number | undefined;
-  getBuffer(key: string): ArrayBuffer | undefined;
+  getBuffer(key: string): MMKVBuffer | undefined;
   getAllKeys(): string[];
   addOnValueChangedListener(callback: (key: string) => void): { remove: () => void };
   remove?(key: string): boolean;


### PR DESCRIPTION
# feat/inspector-adb-reverse-and-tabs-fix

## Purpose

Improve Inspector and Metro proxy behavior: FSD refactor for title bar and tabs visibility, and fix React Native Inspector reconnect and Redux/AsyncStorage after refresh.

## Work content

- **Inspector FSD refactor**
  - Added `features/tabs-visibility`: `getTabsVisibility` / `useTabsVisibility` and tab visibility toggle UI; used by the title bar and by the devtools page and routes.
  - Added `widgets/title-bar`: `TitleBar` component that uses tabs visibility; root layout now only handles server start, SSE, and settings modal and composes `<TitleBar />`.
  - Tests were added for the tabs-visibility feature (`getTabsVisibility` for unset/"true"/"false"/other, `useTabsVisibility` for initial state, toggle updating state and localStorage, and `tabs-visibility-change` dispatch).

- **Server Metro proxy**
  - When an RN inspector is already connected and a new Metro proxy DevTools connection is established (e.g. after Inspector refresh), the server sends the **reconnect inject** again so `__ChromeRemoteDevToolsReconnect()` runs and the app reconnects.
  - When a **new** DevTools client connects and an RN inspector is already present, the server sends **cached Redux stores** to that client so the Redux/AsyncStorage panel works after refresh.
  - Added `INJECT_RECONNECT_EXPRESSION` and a unit test that checks the inject payload shape (`Runtime.evaluate` with expression containing `__ChromeRemoteDevToolsReconnect`).

- **React Native Inspector – MMKV DevTools**
  - Fixed type error when passing v3 (legacy) MMKV to `registerMMKVDevTools`: `getBuffer` now typed as `ArrayBufferLike` so `SharedArrayBuffer` is accepted; exported `MMKVStorageInput`; example app uses it for the storages object.
  - Reduced intermittent empty MMKV tab in Tauri build: `setMMKVConnectionReady()` now calls `sendAllSnapshots()` so snapshots are sent when the WebSocket connects, even if the MMKV panel had opened earlier.

- **Inspector (Tauri) – adb reverse and Toast**
  - Replaced custom adb result popup with Radix UI Toast (`@radix-ui/react-toast`); Provider and Viewport in app root, Toast in title bar for success/error.
  - adb reverse button now runs reverse for **both** Server URL port (8080) and Metro URL port (8081); added `getMetroPort()` in server-url and run both via `Promise.all` when ports differ. Single toast summarizes result.

## How to test

- **Inspector:** Run Inspector (web or Tauri), toggle tabs visibility from the title bar; confirm devtools page and routes respect the setting. Run `bun test` in the inspector package for tabs-visibility tests.
- **Metro proxy:** Connect an RN app via Metro proxy, open Inspector, then refresh the Inspector tab; confirm the app reconnects and Redux/AsyncStorage panel shows data. Run `cargo test -p chrome-remote-devtools-server` for the inject payload test.
- **MMKV (Tauri):** Run RN example with Tauri Inspector; open MMKV tab before/after connection; confirm all storages (user, cache, default, legacy) appear. No type error when building the example with v3 legacy storage.
- **adb reverse (Tauri):** In Tauri Inspector, click the terminal icon in the title bar; confirm a toast (not alert) shows success or error; confirm both tcp:8080 and tcp:8081 are reversed when Server and Metro URLs use different ports.

Relates to #59
